### PR TITLE
PHP7 compatibility: replace preg_replace with e modifier

### DIFF
--- a/Text/Highlighter/Renderer/Console.php
+++ b/Text/Highlighter/Renderer/Console.php
@@ -179,7 +179,9 @@ class Text_Highlighter_Renderer_Console extends Text_Highlighter_Renderer
             $nlines = substr_count($this->_output, "\n") + 1;
             $len = strlen($nlines);
             $i = 1;
-            $this->_output = preg_replace('~^~em', '" " . str_pad($i++, $len, " ", STR_PAD_LEFT) . ": "', $this->_output);
+            $this->_output = preg_replace_callback('~^~m', function () use (&$i, $len) {
+                return ' ' . str_pad($i++, $len, ' ', STR_PAD_LEFT) . ': ';
+            }, $this->_output);
         }
         $this->_output .= HL_CONSOLE_DEFCOLOR . "\n";
     }


### PR DESCRIPTION
Removed the deprecated (and as of PHP7 removed) e modifier for the preg_replace function and replaced it by preg_replace_callback