### PR TITLE
Solves [] operator fatal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ vendor
 *.tgz
 
 build/
+/nbproject/

--- a/Text/Highlighter/Generator.php
+++ b/Text/Highlighter/Generator.php
@@ -439,7 +439,7 @@ class Text_Highlighter_Generator extends  XML_Parser
         if (!strlen($text)) {
             $this->_error(TEXT_HIGHLIGHTER_EMPTY_RE);
         }
-        if (!strlen($text) || $text{0} != '/') {
+        if (!strlen($text) || $text[0] != '/') {
             $text = '/' . $text . '/';
         }
         if (!$case) {

--- a/Text/Highlighter/Renderer/BB.php
+++ b/Text/Highlighter/Renderer/BB.php
@@ -128,6 +128,14 @@ class Text_Highlighter_Renderer_BB extends Text_Highlighter_Renderer_Array
         'inlinetags' => 'Blue',
     );
 
+    /**
+     * Highlighted code
+     *
+     * @var string
+     */
+    var $_output_bb = '';
+    
+    
     /**#@-*/
 
     /**
@@ -203,18 +211,18 @@ class Text_Highlighter_Renderer_BB extends Text_Highlighter_Renderer_Array
             $item_tag = $this->_tag_brackets['start'] .
                         $this->_bb_tags['list_item'] .
                         $this->_tag_brackets['end'];
-            $this->_output = $item_tag . str_replace("\n", "\n". $item_tag .' ', $bb_output);
-            $this->_output = $this->_tag_brackets['start'] .
+            $this->_output_bb = $item_tag . str_replace("\n", "\n". $item_tag .' ', $bb_output);
+            $this->_output_bb = $this->_tag_brackets['start'] .
                              $this->_bb_tags['list'] .
                              $this->_tag_brackets['end'] .
-                             $this->_output .
+                             $this->_output_bb .
                              $this->_tag_brackets['start'] .
                              '/'.
                              $this->_bb_tags['list'] .
                              $this->_tag_brackets['end']
                              ;
         } else {
-            $this->_output = $this->_tag_brackets['start'] .
+            $this->_output_bb = $this->_tag_brackets['start'] .
                              $this->_bb_tags['code'] .
                              $this->_tag_brackets['end'] .
                              $bb_output .
@@ -224,6 +232,19 @@ class Text_Highlighter_Renderer_BB extends Text_Highlighter_Renderer_Array
                              $this->_tag_brackets['end'];
         }
     }
+
+     /**
+     * Get generated output
+     *
+     * @abstract
+     * @return array Highlighted code as an array
+     * @access public
+     */
+    function getOutput()
+    {
+        return $this->_output_bb;
+    }
+
 
 }
 

--- a/Text/Highlighter/Renderer/Console.php
+++ b/Text/Highlighter/Renderer/Console.php
@@ -179,7 +179,9 @@ class Text_Highlighter_Renderer_Console extends Text_Highlighter_Renderer
             $nlines = substr_count($this->_output, "\n") + 1;
             $len = strlen($nlines);
             $i = 1;
-            $this->_output = preg_replace('~^~em', '" " . str_pad($i++, $len, " ", STR_PAD_LEFT) . ": "', $this->_output);
+            $this->_output = preg_replace_callback('~^~em', function($m) use (&$i, $len) {
+                return " " . str_pad($i++, $len, " ", STR_PAD_LEFT) . ": ";
+            },  $this->_output);
         }
         $this->_output .= HL_CONSOLE_DEFCOLOR . "\n";
     }

--- a/Text/Highlighter/Renderer/Html.php
+++ b/Text/Highlighter/Renderer/Html.php
@@ -453,6 +453,13 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
 
     }
     
+     /**
+     * Get generated output
+     *
+     * @abstract
+     * @return array Highlighted code as an array
+     * @access public
+     */
     function getOutput()
     {
         return $this->_output_html;

--- a/Text/Highlighter/Renderer/Html.php
+++ b/Text/Highlighter/Renderer/Html.php
@@ -224,6 +224,7 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
      */
     function reset()
     {
+	parent::reset();
         $this->_output_html = '';
         if (isset($this->_options['numbers'])) {
             $this->_numbers = (int)$this->_options['numbers'];

--- a/Text/Highlighter/Renderer/Html.php
+++ b/Text/Highlighter/Renderer/Html.php
@@ -160,7 +160,7 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
      *
      * @var string
      */
-    var $_output = '';
+    var $_output_html = '';
 
     /**
      * Mapping of keywords to formatting rules using inline styles
@@ -224,7 +224,7 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
      */
     function reset()
     {
-        $this->_output = '';
+        $this->_output_html = '';
         if (isset($this->_options['numbers'])) {
             $this->_numbers = (int)$this->_options['numbers'];
             if ($this->_numbers != HL_NUMBERS_LI
@@ -342,7 +342,7 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
 
             // additional whitespace for browsers that do not display
             // empty list items correctly
-            $this->_output = '<li>&nbsp;' . $html_output . '</li>';
+            $this->_output_html = '<li>&nbsp;' . $html_output . '</li>';
 
             $start = '';
             if ($this->_numbers == HL_NUMBERS_OL && intval($this->_numbers_start) > 0)  {
@@ -355,9 +355,9 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
             }
 
 
-            $this->_output = '<' . $list_tag . $start
+            $this->_output_html = '<' . $list_tag . $start
                              . ' ' . $this->_getStyling('main', false) . '>'
-                             . $this->_output . '</'. $list_tag .'>';
+                             . $this->_output_html . '</'. $list_tag .'>';
 
         // render a table
         } else if ($this->_numbers == HL_NUMBERS_TABLE) {
@@ -374,16 +374,16 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
             for ($i=1; $i <= $nlines; $i++) {
                 $numbers .= ($start_number + $i) . "\n";
             }
-            $this->_output = '<table ' . $this->_getStyling('table', false) . ' width="100%"><tr>' .
+            $this->_output_html = '<table ' . $this->_getStyling('table', false) . ' width="100%"><tr>' .
                              '<td '. $this->_getStyling('gutter', false) .' align="right" valign="top">' .
                              '<pre>' . $numbers . '</pre></td><td '. $this->_getStyling('main', false) .
                              ' valign="top"><pre>' .
                              $html_output . '</pre></td></tr></table>';
         }
         if (!$this->_numbers) {
-            $this->_output = '<pre>' . $html_output . '</pre>';
+            $this->_output_html = '<pre>' . $html_output . '</pre>';
         }
-        $this->_output = '<div ' . $this->_getStyling('main', false) . '>' . $this->_output . '</div>';
+        $this->_output_html = '<div ' . $this->_getStyling('main', false) . '>' . $this->_output_html . '</div>';
     }
 
 
@@ -452,6 +452,12 @@ class Text_Highlighter_Renderer_Html extends Text_Highlighter_Renderer_Array
         }
 
     }
+    
+    function getOutput()
+    {
+        return $this->_output_html;
+    }
+
 }
 
 /*

--- a/Text/Highlighter/Renderer/HtmlTags.php
+++ b/Text/Highlighter/Renderer/HtmlTags.php
@@ -103,6 +103,14 @@ class Text_Highlighter_Renderer_HtmlTags extends Text_Highlighter_Renderer_Array
         'inlinetags' => '',
     );
 
+    /**
+     * Highlighted code
+     *
+     * @var string
+     */
+    var $_output_html = '';
+    
+    
     /**#@-*/
 
     /**
@@ -167,12 +175,23 @@ class Text_Highlighter_Renderer_HtmlTags extends Text_Highlighter_Renderer_Array
             /* additional whitespace for browsers that do not display
             empty list items correctly */
             $html_output = '<li>&nbsp;' . str_replace("\n", "</li>\n<li>&nbsp;", $html_output) . '</li>';
-            $this->_output = '<ol>' . str_replace(' ', '&nbsp;', $html_output) . '</ol>';
+            $this->_output_html = '<ol>' . str_replace(' ', '&nbsp;', $html_output) . '</ol>';
         } else {
-            $this->_output = '<pre>' . $html_output . '</pre>';
+            $this->_output_html = '<pre>' . $html_output . '</pre>';
         }
     }
-
+    
+     /**
+     * Get generated output
+     *
+     * @abstract
+     * @return array Highlighted code as an array
+     * @access public
+     */
+    function getOutput()
+    {
+        return $this->_output_html;
+    }
 
 }
 

--- a/Text/Highlighter/Renderer/JSON.php
+++ b/Text/Highlighter/Renderer/JSON.php
@@ -42,6 +42,14 @@ require_once 'Text/Highlighter/Renderer/Array.php';
 class Text_Highlighter_Renderer_JSON extends Text_Highlighter_Renderer_Array
 {
 
+
+    /**
+     * Highlighted code
+     *
+     * @var string
+     */
+    var $_output_json = '';
+
     /**
      * Signals that no more tokens are available
      *
@@ -67,9 +75,21 @@ class Text_Highlighter_Renderer_JSON extends Text_Highlighter_Renderer_Array
 
         }
 
-        $this->_output  = '['. implode(',', $json_array) .']';
-        $this->_output = str_replace("\n", '\n', $this->_output);
+        $this->_output_json  = '['. implode(',', $json_array) .']';
+        $this->_output_json = str_replace("\n", '\n', $this->_output);
 
+    }
+
+     /**
+     * Get generated output
+     *
+     * @abstract
+     * @return array Highlighted code as an array
+     * @access public
+     */
+    function getOutput()
+    {
+        return $this->_output_json;
     }
 
 

--- a/Text/Highlighter/Renderer/XML.php
+++ b/Text/Highlighter/Renderer/XML.php
@@ -52,7 +52,13 @@ class Text_Highlighter_Renderer_XML extends Text_Highlighter_Renderer_Array
      */
     var $_serializer_options = array();
 
-
+    /**
+     * Highlighted code
+     *
+     * @var string
+     */
+    var $_output_xml = '';
+    
     /**
      * Resets renderer state
      *
@@ -86,10 +92,21 @@ class Text_Highlighter_Renderer_XML extends Text_Highlighter_Renderer_Array
         $serializer = new XML_Serializer($this->_serializer_options);
         $result = $serializer->serialize($output);
         if ($result === true) {
-            $this->_output = $serializer->getSerializedData();
+            $this->_output_xml = $serializer->getSerializedData();
         }
     }
 
+     /**
+     * Get generated output
+     *
+     * @abstract
+     * @return array Highlighted code as an array
+     * @access public
+     */
+    function getOutput()
+    {
+        return $this->_output_xml;
+    }
 
 }
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "./"
     ],
     "license": "PHP License",
-    "name": "pear/text_highlighter",
+    "name": "siu-toba/text_highlighter",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Text_Highlighter",
         "source": "https://github.com/pear/Text_Highlighter"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "type": "library",
     "require": {
         "pear/pear_exception": "*",
-        "pear/pear": "*"
+        "pear/pear-core-minimal": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "*"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     },
     "type": "library",
     "require": {
-        "pear/pear_exception": "*",
         "php": ">=5.4.0",
         "pear/pear-core-minimal": "~1.10.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "./"
     ],
     "license": "PHP-3.01",
-    "name": "pear/text_highlighter",
+    "name": "siu-toba/text_highlighter",
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=Text_Highlighter",
         "source": "https://github.com/pear/Text_Highlighter"


### PR DESCRIPTION
Classes extended from Text_Highlighter_Renderer_Array were using `$_output` as array and string simultaneuosly through inheritance. Using [] operator on a string raises a fatal error.

Problem arises from Text_Highlighter_Renderer_Array::acceptToken method.

