### PR TITLE
Fix PHP 8.2 compatibility

### DIFF
--- a/Text/Highlighter.php
+++ b/Text/Highlighter.php
@@ -92,6 +92,7 @@ define ('HL_INFINITY',      1000000000);
  * @access public
  */
 
+#[AllowDynamicProperties]
 class Text_Highlighter
 {
     // {{{ members

--- a/Text/Highlighter/Renderer.php
+++ b/Text/Highlighter/Renderer.php
@@ -33,6 +33,7 @@
  * @abstract
  */
 
+#[AllowDynamicProperties]
 class Text_Highlighter_Renderer
 {
     /**


### PR DESCRIPTION
PHP deprecated dynamic properties with the release of version 8.2 [php.watch](https://php.watch/versions/8.2/dynamic-properties-deprecated), doing so will now generate deprecation errors. Adding the `#[AllowDynamicProperties]` attribute to a class allows the use of dynamic properties again. The attribute is automatically inherited.